### PR TITLE
Use Visual Studio Code Tunnels extension instead of SSH

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,21 +43,21 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        uses: sigstore/cosign-installer@v3.5.0
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: 'v2.2.4'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -79,7 +79,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,4 @@ USER root
 
 COPY init /.init
 
-EXPOSE 22
-
 CMD ["/.init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN yes | unminimize
 
 # System: Install essentials
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    openssh-server openssh-client \
     sudo nano wget curl lsof htop git ack ca-certificates build-essential locales ufw rsyslog strace unzip zip gzip tar command-not-found screen bc \
     iputils-ping iputils-tracepath traceroute iproute2 iproute2-doc dnsutils mmdb-bin nmap ngrep tcpdump ffmpeg jq needrestart unattended-upgrades cloc \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev 
@@ -21,6 +20,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 RUN wget https://github.com/fastfetch-cli/fastfetch/releases/download/$(curl -s https://api.github.com/repos/fastfetch-cli/fastfetch/releases/latest | jq -r '.tag_name')/fastfetch-linux-amd64.deb && \
     dpkg -i fastfetch-linux-amd64.deb && \
     rm -rf fastfetch-linux-amd64.deb
+
+# System: Install Code CLI (Visual Studio Code)
+RUN curl -sL "https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-x64" -o /tmp/vscode-cli.tar.gz && \
+    tar -xf /tmp/vscode-cli.tar.gz -C /usr/bin && \
+    rm -rf /tmp/vscode-cli.tar.gz && \
+    mkdir -p /data/cli && \
+    mkdir -p /data/server && \
+    mkdir -p /data/extensions
 
 # System: Install Docker
 RUN install -m 0755 -d /etc/apt/keyrings && \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Development Container
+A development container running a Visual Studio Code Tunnel server for all your remote development needs.
 
 ## Features
-- Preinstalled tools (pyenv, poetry, nvm, rustup, docker)
-- SSH server for remote development using Visual Studio Code or JetBrains IDEs
-- Passthrough of GPG and SSH keys, along with Git configurations
+- Preinstalled tools (pyenv, poetry, nvm, rustup, sdkman, docker)
+- Passthrough of GPG keys, along with Git configurations
 - Latest Ubuntu rolling release (unminimized)
 
 ## Setup
@@ -25,12 +25,12 @@ docker run -d \
 --name dev-container \
 --hostname dev \
 --restart unless-stopped \
--p 2222:22 \
 -e PASSWORD="YOUR_PASSWORD" \
--e KEYS="YOUR_KEYS" \
 -v ~/.gnupg:/volumes/.gnupg:ro \
 -v ~/.gitconfig:/volumes/.gitconfig:ro \
 -v ./workspaces:/workspaces \
+-v ./data/:/data \
 -v home:/home/ubuntu \
 ghcr.io/thaddeuskkr/dev-container:main
 ```
+The Docker `run` command above tries to replicate the behaviour from the Docker Compose file - there might be some discrepancies.

--- a/compose.yml
+++ b/compose.yml
@@ -1,24 +1,18 @@
 services:
   dev:
     container_name: dev-container
-    hostname: dev
+    hostname: dev # The hostname is the name of the tunnel (by default)
     image: ghcr.io/thaddeuskkr/dev-container:main
     restart: unless-stopped
     environment:
       PASSWORD: YOUR_PASSWORD # This is set for the users "ubuntu" and "root"
-      KEYS: | # A list of public keys to copy to ~/.ssh/authorized_keys
-        ssh-rsa abc
-    ports:
-      - "2222:22"
     volumes:
       - ~/.gnupg:/volumes/.gnupg:ro
       - ~/.gitconfig:/volumes/.gitconfig:ro
       - ./workspaces:/workspaces
+      - ./data/:/data
+      # - /var/run/docker.sock:/var/run/docker.sock # Optional - if you want to use Docker within the container
       - home:/home/ubuntu
 
 volumes:
   home:
-
-networks:
-  default:
-    name: dev

--- a/init
+++ b/init
@@ -8,4 +8,4 @@ cp -R /volumes/.gnupg/* /home/ubuntu/.gnupg
 cp /volumes/.gitconfig /home/ubuntu
 chown -R ubuntu:ubuntu /home/ubuntu/.gnupg
 chown -R ubuntu:ubuntu /home/ubuntu/.gitconfig
-code tunnel --accept-server-license-terms --server-data-dir /data/server --extensions-dir /data/extensions --cli-data-dir /data/cli
+sudo -u ubuntu bash -c 'code tunnel --accept-server-license-terms --server-data-dir /data/server --extensions-dir /data/extensions --cli-data-dir /data/cli'

--- a/init
+++ b/init
@@ -1,6 +1,4 @@
 #!/bin/bash
-chown -R ubuntu:ubuntu /workspaces
-chown -R ubuntu:ubuntu /data
 echo "root:$PASSWORD" | chpasswd
 echo "ubuntu:$PASSWORD" | chpasswd
 mkdir -p /home/ubuntu/.gnupg
@@ -8,4 +6,6 @@ cp -R /volumes/.gnupg/* /home/ubuntu/.gnupg
 cp /volumes/.gitconfig /home/ubuntu
 chown -R ubuntu:ubuntu /home/ubuntu/.gnupg
 chown -R ubuntu:ubuntu /home/ubuntu/.gitconfig
+chown -R ubuntu:ubuntu /workspaces
+chown -R ubuntu:ubuntu /data
 sudo -u ubuntu bash -c 'code tunnel --accept-server-license-terms --server-data-dir /data/server --extensions-dir /data/extensions --cli-data-dir /data/cli'

--- a/init
+++ b/init
@@ -1,13 +1,11 @@
 #!/bin/bash
 chown -R ubuntu:ubuntu /workspaces
+chown -R ubuntu:ubuntu /data
 echo "root:$PASSWORD" | chpasswd
 echo "ubuntu:$PASSWORD" | chpasswd
-mkdir -p /home/ubuntu/.ssh
 mkdir -p /home/ubuntu/.gnupg
-echo "$KEYS\n" >> /home/ubuntu/.ssh/authorized_keys
 cp -R /volumes/.gnupg/* /home/ubuntu/.gnupg
 cp /volumes/.gitconfig /home/ubuntu
-chown -R ubuntu:ubuntu /home/ubuntu/.ssh
 chown -R ubuntu:ubuntu /home/ubuntu/.gnupg
 chown -R ubuntu:ubuntu /home/ubuntu/.gitconfig
-/usr/sbin/sshd -D
+code tunnel --accept-server-license-terms --server-data-dir /data/server --extensions-dir /data/extensions --cli-data-dir /data/cli


### PR DESCRIPTION
This pull request makes the development container use tunnels for remote development instead of SSH - which is more secure - and probably better on public networks, especially if they block SSH connections.  

I haven't tested if Tunnels works when SSH is blocked, but I will soon.